### PR TITLE
feat: implement sbom generation as a cli tool

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -261,6 +261,31 @@ jobs:
           path: ./audit/results
           destination: audit
 
+  cli-check:
+    executor: default-docker
+    steps:
+      - run:
+          name: Install general dependencies
+          command: *defaults_docker_Dependencies
+      - checkout
+      - run:
+          <<: *defaults_configure_nvm
+      - run:
+          <<: *defaults_display_versions
+      - restore_cache:
+          key: dependency-cache-{{ .Environment.CIRCLE_SHA1 }}
+      - run:
+          name: Check shebang lines in bin scripts
+          command: |
+            set -e
+            for file in bin/*; do
+              if [[ "$file" == *.js ]]; then
+                head -n 1 "$file" | grep -qx '#!/usr/bin/env node' || { echo "$file missing #!/usr/bin/env node"; exit 1; }
+              elif [[ "$file" == *.sh ]]; then
+                head -n 1 "$file" | grep -qx '#!/bin/bash' || { echo "$file missing #!/bin/bash"; exit 1; }
+              fi
+            done
+
   audit-licenses:
     executor: default-docker
     steps:
@@ -489,6 +514,17 @@ workflows:
                 - /feature*/
                 - /bugfix*/
       - vulnerability-check:
+          context: org-global
+          requires:
+            - setup
+          filters:
+            tags:
+              only: /.*/
+            branches:
+              ignore:
+                - /feature*/
+                - /bugfix*/
+      - cli-check:
           context: org-global
           requires:
             - setup

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ node_modules/
 data/
 
 /repos-list.json
+
+.vscode

--- a/README.md
+++ b/README.md
@@ -14,26 +14,43 @@ This utility provides a script to scan the dependencies and transitive dependenc
 
 - **Configurable Mode:** Choose between warning or error modes using configuration or environment variables.
 
-- **Reason:** Each deprecated dependency includes a reason, often suggesting alternative packages.
+- **Reason Included:** Each deprecated dependency includes a reason for deprecation, often suggesting alternative packages.
+
+- **Type of Repo:** This utility can be used for standard npm based repositories and yarn based monorepos as well.
 
 ## Usage
 
 You can run the utility directly from the command line once it is installed.<br>
-`npm install @mojaloop/ml-depcheck-utility`<br>
-`check-deprecations`<br>
+
+```bash
+npm install @mojaloop/ml-depcheck-utility
+check-deprecations-npm #for npm based repositories
+check-deprecations-yarn #for yarn based repositories
+```
+
+Using npx to run the command :<br>
+
+```bash
+npx --package @mojaloop/ml-depcheck-utility check-deprecations-npm
+npx --package @mojaloop/ml-depcheck-utility check-deprecations-yarn
+```
 
 ## Changing the Configuration Mode
 
-You can change the mode in two ways:
+You can override the configuration by setting the MODE environment variable before running the utility via using enviornment variables. It supports two modes:
 
-1. **Via the config/default.json file:**
-   The default configuration can be modified by updating the mode setting in the config/default.json file. It supports two modes:
-   - **warning:** Will log deprecated dependencies as warnings (default behavior).
-   - **error:** Will log deprecated dependencies as errors and exit the process with a non-zero exit code.
-2. **Via Environment Variable:**
-   You can override the configuration by setting the MODE environment variable before running the utility. The commands are as follows:
-   - `MODE=warning check-deprecations`
-   - `MODE=error check-deprecations`
+- **warning:** Will log deprecated dependencies as warnings (default behavior).
+- **error:** Will log deprecated dependencies as errors and exit the process with a non-zero exit code.<br>
+
+The commands are as follows, for npm based repositories:
+
+- `MODE=warning check-deprecations-npm`
+- `MODE=error check-deprecations-npm`
+
+The commands are as follows, for yarn based repositories:
+
+- `MODE=warning check-deprecations-yarn`
+- `MODE=error check-deprecations-yarn`
 
 ## Example Output
 
@@ -143,22 +160,27 @@ At the end of the process, an aggregated SBOM is generated. This SBOM:
   - License
   - Publish details
 
+### 4. Easy generation using CLI :
+
+Generate a the SBOM effortlessly using the CLI by a single command. You can either:
+
+- Specify the version manually as a CLI argument, or
+- Let the script auto-detect the version from the project's manifest file (e.g., package.json).
+
 ---
 
 ## How to Use This Tool
 
 To use the SBOM generation tool, follow these steps:
 
-1. **Clone the Repository**:
-   Clone this repository to your local machine:
+1. **Install the package**:
 
    ```bash
-   git clone https://github.com/mojaloop/ml-depcheck-utility.git
-   cd ml-depcheck-utility
+   npm install @mojaloop/ml-depcheck-utility
    ```
 
 2. **Install Dependencies**:
-   Use `npm` to install all required dependencies:
+   Use `npm` to install all required dependencies in the repository:
 
    ```bash
    npm install
@@ -169,20 +191,27 @@ To use the SBOM generation tool, follow these steps:
    - **For individual repositories**:Use this mode if you want to generate SBOMs for one repository at a time.
      - **For npm-based project**:
        ```bash
-       bash src/individual-repo/npm/generate-sbom.sh
+       generate-sbom-npm
        ```
      - **For yarn-based projects**:
        ```bash
-       bash src/individual-repo/yarn/generate-sbom.sh
+       generate-sbom-yarn
+       ```
+     - **Specifying the version**:
+       ```bash
+       generate-sbom-npm <version>
+       ```
+       ```bash
+       generate-sbom-yarn <version>
        ```
    - **Generate Aggregate SBOM for Multiple Repositories**: Use this mode to generate SBOMs for a list of repositories, either the default set or a custom list.
      - **Using Default Repository List**:
      ```bash
-     bash src/aggregate/generate-sbom.sh
+     generate-aggregate
      ```
      - **Using Custom Repository List**:
      ```bash
-     bash src/aggregate/generate-sbom.sh custom-repos-list.json
+     generate-aggregate custom-repos-list.json
      ```
 
 ---

--- a/bin/generate-aggregate.sh
+++ b/bin/generate-aggregate.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Get the absolute path to the directory where this script is
+SCRIPT_DIR="$(cd "$(dirname "$(realpath "$0")")" && pwd)"
+
+# Run your actual script from your package directory
+bash "$SCRIPT_DIR/../src/aggregate/generate-sbom.sh"

--- a/bin/generate-aggregate.sh
+++ b/bin/generate-aggregate.sh
@@ -4,4 +4,4 @@
 SCRIPT_DIR="$(cd "$(dirname "$(realpath "$0")")" && pwd)"
 
 # Run your actual script from your package directory
-bash "$SCRIPT_DIR/../src/aggregate/generate-sbom.sh"
+bash "$SCRIPT_DIR/../src/aggregate/generate-sbom.sh" "$@"

--- a/bin/generate-sbom-npm.sh
+++ b/bin/generate-sbom-npm.sh
@@ -4,4 +4,4 @@
 SCRIPT_DIR="$(cd "$(dirname "$(realpath "$0")")" && pwd)"
 
 # Run your actual script from your package directory
-bash "$SCRIPT_DIR/../src/individual-repo/npm/generate-sbom.sh"
+bash "$SCRIPT_DIR/../src/individual-repo/npm/generate-sbom.sh" "$@"

--- a/bin/generate-sbom-npm.sh
+++ b/bin/generate-sbom-npm.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Get the absolute path to the directory where this script is
+SCRIPT_DIR="$(cd "$(dirname "$(realpath "$0")")" && pwd)"
+
+# Run your actual script from your package directory
+bash "$SCRIPT_DIR/../src/individual-repo/npm/generate-sbom.sh"

--- a/bin/generate-sbom-yarn.sh
+++ b/bin/generate-sbom-yarn.sh
@@ -4,4 +4,4 @@
 SCRIPT_DIR="$(cd "$(dirname "$(realpath "$0")")" && pwd)"
 
 # Run your actual script from your package directory
-bash "$SCRIPT_DIR/../src/individual-repo/yarn/generate-sbom.sh"
+bash "$SCRIPT_DIR/../src/individual-repo/yarn/generate-sbom.sh" "$@"

--- a/bin/generate-sbom-yarn.sh
+++ b/bin/generate-sbom-yarn.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Get the absolute path to the directory where this script is
+SCRIPT_DIR="$(cd "$(dirname "$(realpath "$0")")" && pwd)"
+
+# Run your actual script from your package directory
+bash "$SCRIPT_DIR/../src/individual-repo/yarn/generate-sbom.sh"

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,10 @@
       },
       "bin": {
         "check-deprecations-npm": "bin/check-deprecations-npm.js",
-        "check-deprecations-yarn": "bin/check-deprecations-yarn.js"
+        "check-deprecations-yarn": "bin/check-deprecations-yarn.js",
+        "generate-aggregate": "bin/generate-aggregate.sh",
+        "generate-sbom-npm": "bin/generate-sbom-npm.sh",
+        "generate-sbom-yarn": "bin/generate-sbom-yarn.sh"
       }
     },
     "node_modules/@cyclonedx/cyclonedx-library": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,10 @@
   "main": "src/index.js",
   "bin": {
     "check-deprecations-npm": "./bin/check-deprecations-npm.js",
-    "check-deprecations-yarn": "./bin/check-deprecations-yarn.js"
+    "check-deprecations-yarn": "./bin/check-deprecations-yarn.js",
+    "generate-sbom-npm": "./bin/generate-sbom-npm.sh",
+    "generate-sbom-yarn": "./bin/generate-sbom-yarn.sh",
+    "generate-aggregate": "./bin/generate-aggregate.sh"
   },
   "repository": {
     "type": "git",

--- a/src/aggregate/generate-sbom.sh
+++ b/src/aggregate/generate-sbom.sh
@@ -2,6 +2,9 @@
 
 json_file=$1  # The first argument passed to the script is the JSON file
 
+# Detect this script's root (inside CLI package)
+SCRIPT_DIR="$(cd "$(dirname "$(realpath "$0")")" && pwd)"
+
 # Check if json_file is provided and the file exists
 mkdir -p ./data
 if [ -f "$json_file" ]; then
@@ -9,15 +12,15 @@ if [ -f "$json_file" ]; then
   cp "$json_file" ./data/repos-list.json
 else
   echo "$json_file not found. Copying ./config/repos-list.json to ./data/repos-list.json"
-  cp ./config/repos-list.json ./data/repos-list.json
+  cp $SCRIPT_DIR/../../config/repos-list.json ./data/repos-list.json
 fi
 
 # Download the sboms for the repos 
 mkdir -p ./data/sbom-csv
-bash src/aggregate/download-sboms.sh
+bash $SCRIPT_DIR/download-sboms.sh
 
 # Make SBOM aggregate 
-node src/aggregate/map-dependencies.js
+node $SCRIPT_DIR/map-dependencies.js
 
 # Save the file 
 mv ./data/sbom.csv sbom.csv

--- a/src/depcheck-yarn.js
+++ b/src/depcheck-yarn.js
@@ -141,7 +141,7 @@ function checkDependencies () {
       // Print direct deprecations
       if (deprecatedDirect.length) {
         foundAny = true
-        const color = mode === 'error' ? YELLOW : RED
+        const color = mode === 'error' ? RED : YELLOW
         console.log(`${color}\nFound ${deprecatedDirect.length} deprecated direct dependencies:\n${RESET}`)
         deprecatedDirect.forEach((r, i) => console.log(`${i + 1}. ${r}`))
       } else {
@@ -151,7 +151,7 @@ function checkDependencies () {
       // Print transitive deprecations
       if (deprecatedTransitive.length) {
         foundAny = true
-        const color = mode === 'error' ? YELLOW : RED
+        const color = mode === 'error' ? RED : YELLOW
         console.log(`${color}\nFound ${deprecatedTransitive.length} deprecated transitive dependencies:\n${RESET}`)
         deprecatedTransitive.forEach((r, i) => console.log(`${i + 1}. ${r}`))
       } else {

--- a/src/individual-repo/npm/generate-sbom.sh
+++ b/src/individual-repo/npm/generate-sbom.sh
@@ -4,7 +4,11 @@
 apk add --no-cache libxslt
 
 # Get repo version from package.json
-REPO_VERSION=$(node -p "require('./package.json').version")
+if [ -n "$1" ]; then
+  REPO_VERSION="$1"
+else
+  REPO_VERSION=$(node -p "require('./package.json').version")
+fi
 
 # Detect this script's root (inside CLI package)
 SCRIPT_DIR="$(cd "$(dirname "$(realpath "$0")")" && pwd)"
@@ -29,7 +33,7 @@ xsltproc $SCRIPT_DIR/components.xslt "./tmp/result-individual/SBOM.xml" > "./tmp
 node $SCRIPT_DIR/append-fields.js
 
 # Save the SBOM with version in filename
-FINAL_SBOM_NAME="sbom-npm-v$REPO_VERSION.csv"
+FINAL_SBOM_NAME="sbom-npm-$REPO_VERSION.csv"
 mv tmp/result-individual/SBOM-final.csv "$FINAL_SBOM_NAME"
 
 #Delete files

--- a/src/individual-repo/npm/generate-sbom.sh
+++ b/src/individual-repo/npm/generate-sbom.sh
@@ -4,20 +4,29 @@
 apk add --no-cache libxslt
 
 # Get repo version from package.json
-REPO_VERSION=$(node -p "require('./tmp/ml-depcheck-utility/package.json').version")
+REPO_VERSION=$(node -p "require('./package.json').version")
+
+# Detect this script's root (inside CLI package)
+SCRIPT_DIR="$(cd "$(dirname "$(realpath "$0")")" && pwd)"
 
 #Install dependencies
-npm install --ignore-scripts --legacy-peer-deps --force
+if ! npm install; then
+  echo "npm install failed, retrying with --legacy-peer-deps..."
+  npm install --ignore-scripts --legacy-peer-deps --force
+fi
+
+#Make temporary directory
+mkdir -p ./tmp
 
 #Generate SBOM
 mkdir -p ./tmp/result-individual
-npx cyclonedx-npm --ignore-npm-errors --output-format "XML" --output-file "./tmp/result-individual/SBOM.xml"
+npx --yes --package @cyclonedx/cyclonedx-npm@3.0.0 -- cyclonedx-npm --ignore-npm-errors --output-format XML --output-file "./tmp/result-individual/SBOM.xml"
 
 #Convert SBOM into csv fornat
-xsltproc tmp/ml-depcheck-utility/src/individual-repo/npm/components.xslt "./tmp/result-individual/SBOM.xml" > "./tmp/result-individual/SBOM.csv"
+xsltproc $SCRIPT_DIR/components.xslt "./tmp/result-individual/SBOM.xml" > "./tmp/result-individual/SBOM.csv"
 
 #Append fields to sbom - deprecated and last publish
-node tmp/ml-depcheck-utility/src/individual-repo/npm/append-fields.js
+node $SCRIPT_DIR/append-fields.js
 
 # Save the SBOM with version in filename
 FINAL_SBOM_NAME="sbom-npm-v$REPO_VERSION.csv"

--- a/src/individual-repo/yarn/generate-sbom.sh
+++ b/src/individual-repo/yarn/generate-sbom.sh
@@ -3,25 +3,31 @@
 #Install xslt processor
 apk add --no-cache libxslt
 
+# Get repo version from package.json
+REPO_VERSION=$(node -p "require('./package.json').version")
+
+# Detect this script's root (inside CLI package)
+SCRIPT_DIR="$(cd "$(dirname "$(realpath "$0")")" && pwd)"
+
 #Install dependencies
 yarn set version stable
 yarn install --mode=skip-build
 
-# Get repo version from package.json
-REPO_VERSION=$(node -p "require('./tmp/ml-depcheck-utility/package.json').version")
+#Make temporary directory
+mkdir -p ./tmp
 
 #Generate SBOM
 mkdir -p ./tmp/result-individual
-yarn dlx @cyclonedx/yarn-plugin-cyclonedx --of XML -o "./tmp/result-individual/SBOM.xml"
+yarn dlx @cyclonedx/yarn-plugin-cyclonedx@3.0.3 --of XML -o "./tmp/result-individual/SBOM.xml"
 
 #Convert SBOM into csv fornat
-xsltproc tmp/ml-depcheck-utility/src/individual-repo/yarn/components.xslt "./tmp/result-individual/SBOM.xml" > "./tmp/result-individual/SBOM.csv"
+xsltproc $SCRIPT_DIR/components.xslt "./tmp/result-individual/SBOM.xml" > "./tmp/result-individual/SBOM.csv"
 
 #Update packages to make it compatible with npm repositories 
-node tmp/ml-depcheck-utility/src/individual-repo/yarn/update-packages.js
+node $SCRIPT_DIR/update-packages.js
 
 #Append fields to sbom - deprecated and last publish
-node tmp/ml-depcheck-utility/src/individual-repo/yarn/append-fields.js
+node $SCRIPT_DIR/append-fields.js
 
 # Save the SBOM with version in the filename
 FINAL_SBOM_NAME="sbom-yarn-v$REPO_VERSION.csv"

--- a/src/individual-repo/yarn/generate-sbom.sh
+++ b/src/individual-repo/yarn/generate-sbom.sh
@@ -4,7 +4,11 @@
 apk add --no-cache libxslt
 
 # Get repo version from package.json
-REPO_VERSION=$(node -p "require('./package.json').version")
+if [ -n "$1" ]; then
+  REPO_VERSION="$1"
+else
+  REPO_VERSION=$(node -p "require('./package.json').version")
+fi
 
 # Detect this script's root (inside CLI package)
 SCRIPT_DIR="$(cd "$(dirname "$(realpath "$0")")" && pwd)"
@@ -30,7 +34,7 @@ node $SCRIPT_DIR/update-packages.js
 node $SCRIPT_DIR/append-fields.js
 
 # Save the SBOM with version in the filename
-FINAL_SBOM_NAME="sbom-yarn-v$REPO_VERSION.csv"
+FINAL_SBOM_NAME="sbom-yarn-$REPO_VERSION.csv"
 mv tmp/result-individual/SBOM-final.csv "$FINAL_SBOM_NAME"
 
 #Delete files


### PR DESCRIPTION
Changes made in this PR:
1. Implemented SBOM generation as a CLI command – Enables users to generate SBOMs directly from the command line.
2. Support for passing release version as an argument – Users can specify the version manually(send from ci-config-orb-build), or it will default to the one in the manifest.
3. Added CI step to validate shebang lines in bin scripts – Ensures consistency and correctness of CLI entry points during automated checks.
